### PR TITLE
Automatically find gpg-agent socket path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+go_import_path: github.com/prep/gpg
 dist: xenial
 
 language: go
@@ -16,11 +17,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y gpgv2
 
-# Start the gpg-agent in the background before running the test suite.
-before_script:
-  - gpg-agent --homedir testdata/gnupg --daemon
-
 script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)
   - test -z $(gofmt -s -l $GO_FILES)
-  - go test -v -race ./...
+  - ./runtests.sh -v -race ./...

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ TODO
 ----
 * There are possibly some unnecessary type conversions happening because `bufio.ReadString()` is used as opposed to `bufio.ReadBytes()`.
 
+Running Tests
+-------------
+
+The tests need a running gpg-agent with the GNUPGHOME environment variable set to the testdata/gnupg directory. To simplify running tests,
+use the `runtests.sh` wrapper script which will set GNUPGHOME, start gpg-agent then run `go test` for you.
+
 License
 -------
 This software is distributed under the BSD-style license found in the LICENSE file.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 gpg-agent
-[![TravisCI](https://travis-ci.org/prep/gpg.svg?branch=master)](https://travis-ci.org/prep/gpg.svg?branch=master)
+[![TravisCI](https://travis-ci.org/prep/gpg.svg?branch=master)](https://travis-ci.org/prep/gpg?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/prep/gpg)](https://goreportcard.com/report/github.com/prep/gpg)
 [![GoDoc](https://godoc.org/github.com/prep/gpg/agent?status.svg)](https://godoc.org/github.com/prep/gpg/agent)
 =========

--- a/agent/conn_test.go
+++ b/agent/conn_test.go
@@ -15,7 +15,7 @@ func init() {
 	}
 
 	var err error
-	if conn, err = Dial("../testdata/gnupg/S.gpg-agent", options); err != nil {
+	if conn, err = Dial("", options); err != nil {
 		panic(err.Error())
 	}
 }

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export GNUPGHOME=${DIR}/testdata/gnupg
+
+gpg-connect-agent reloadagent /bye
+
+go test $@


### PR DESCRIPTION
Adds code that uses the gpgconf command to find the gpg-agent socket path. The old behaviour is kept, it's only if the call to agent.Dial has the empty string as filename argument that the code will try to find the socket automatically.

Tested on Ubuntu bionic. 

Also made a few minor changes to the README, and made travis builds work even on forks. In addition, created a script for running the tests locally.

Please point out any go-related beginners mistakes, it's my first go code :-)