### PR TITLE
Updated keyScan to ignore trailing spaces in KEYINFO attributes

### DIFF
--- a/agent/conn.go
+++ b/agent/conn.go
@@ -115,7 +115,14 @@ func (conn *Conn) Close() error {
 }
 
 func keyScan(key *Key, line string) error {
-	parts := strings.Split(line, " ")
+	unfilteredParts := strings.Split(line, " ")
+	parts := []string{}
+	for _, p := range unfilteredParts {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+
 	if len(parts) != 10 {
 		return fmt.Errorf("illegal format for KEYINFO line")
 	}


### PR DESCRIPTION
Hey,
I've recently ran into a rather odd issue where some keys have a trailing space at the end of the card ID:
```
> keyinfo --show-fpr --list --ssh-fpr
S KEYINFO 61D048F46EE1DCE... T D2760001240102010006064000390000  OPENPGP.3 - - MD5:9b:c8:3c:7b:44:... - -
```

This breaks key scanning as the scanner thinks there are 11 parts to it instead of 10.  This change should be safe as gpg-agent returns a dash (-) when the value is actually empty.